### PR TITLE
fix: skip unnecessary test runs for bot-generated and non-critical PRs

### DIFF
--- a/.github/workflows/pr-testing-with-test-project.yml
+++ b/.github/workflows/pr-testing-with-test-project.yml
@@ -1,13 +1,37 @@
-#This workflow runs the tests in the test projects to make sure the generator works as a library where it is a Node dependency along with the template.
 name: Test using test project
 
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'apps/'
+      - 'packages/'
+      - '.github/workflows/'
+      - '!/*.md'
+      - '!docs/**'
 
 jobs:
+  should-test:
+    runs-on: ubuntu-latest
+    outputs:
+      run_tests: ${{ steps.check.outputs.run_tests }}
+    steps:
+      - name: Check if tests should run
+        id: check
+        run: |
+          # Skip for bot PRs with specific titles
+          if [[ "${{ github.actor }}" == "asyncapi-bot" && "${{ github.event.pull_request.title }}" =~ ^(ci:\ update|chore\(release\):) ]] || \
+             [[ "${{ github.actor }}" == "allcontributors[bot]" && "${{ github.event.pull_request.title }}" =~ ^docs: ]]; then
+            echo "run_tests=false" >> $GITHUB_OUTPUT
+          else
+            echo "run_tests=true" >> $GITHUB_OUTPUT
+          fi
+
   test:
-    if: github.event.pull_request.draft == false
+    needs: should-test
+    if: needs.should-test.outputs.run_tests == 'true' && github.event.pull_request.draft == false
     name: Test generator as dependency with Node ${{ matrix.node }}
     runs-on: ubuntu-latest
     strategy:
@@ -16,6 +40,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        
       - name: Run test
         run: NODE_IMAGE_TAG=${{ matrix.node }} docker compose up --abort-on-container-exit --remove-orphans --force-recreate
         working-directory: ./apps/generator/test/test-project


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- Updated the pr-testing-with-test-project.yml workflow to refine triggers and exclude irrelevant changes.

Related Issue(s)
Fixes #1335

## Testing

- Verified the solution by making minor changes in README.md and CODE_OF_CONDUCT.md

- Confirmed that tests for Node versions 18 and 20 were successfully skipped as intended.

<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The 3rd option will not automatically close the issue after the merge. -->